### PR TITLE
Fix some clang warnings

### DIFF
--- a/printf.c
+++ b/printf.c
@@ -383,12 +383,12 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
   int whole = (int)value;
   double tmp = (value - whole) * pow10[prec];
   unsigned long frac = (unsigned long)tmp;
-  diff = tmp - frac;
+  diff = tmp - (double)frac;
 
   if (diff > 0.5) {
     ++frac;
     // handle rollover, e.g. case 0.99 with prec 1 is 1.0
-    if (frac >= pow10[prec]) {
+    if ((double)frac >= pow10[prec]) {
       frac = 0;
       ++whole;
     }
@@ -561,7 +561,9 @@ static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
     // output the exponential symbol
     out((flags & FLAGS_UPPERCASE) ? 'E' : 'e', buffer, idx++, maxlen);
     // output the exponent value
-    idx = _ntoa_long(out, buffer, idx, maxlen, (expval < 0) ? -expval : expval, expval < 0, 10, 0, minwidth-1, FLAGS_ZEROPAD | FLAGS_PLUS);
+    idx = _ntoa_long(out, buffer, idx, maxlen,
+        (expval < 0) ? (unsigned int)-expval : (unsigned int)expval,
+        expval < 0, 10, 0, minwidth - 1, FLAGS_ZEROPAD | FLAGS_PLUS);
     // might need to right-pad spaces
     if (flags & FLAGS_LEFT) {
       while (idx - start_idx < width) out(' ', buffer, idx++, maxlen);


### PR DESCRIPTION
Fix some of the following warnings from clang-11 `-Weverything`:

```bash
❯ clang-11 -Wall -Wextra -Weverything -c printf.c -o /dev/null
In file included from printf.c:36:
./printf.h:33:9: warning: macro name is a reserved identifier [-Wreserved-id-macro]
 #define _PRINTF_H_
        ^
printf.c:386:16: warning: implicit conversion from 'unsigned long' to 'double' may lose precision [-Wimplicit-int-float-conversion]
  diff = tmp - frac;
             ~ ^~~~
printf.c:391:9: warning: implicit conversion from 'unsigned long' to 'double' may lose precision [-Wimplicit-int-float-conversion]
    if (frac >= pow10[prec]) {
        ^~~~ ~~
printf.c:564:63: warning: operand of ? changes signedness: 'int' to 'unsigned long' [-Wsign-conversion]
    idx = _ntoa_long(out, buffer, idx, maxlen, (expval < 0) ? -expval : expval, expval < 0, 10, 0, minwidth-1, FLAGS_ZEROPAD | FLAGS_PLUS);
          ~~~~~~~~~~                                          ^~~~~~~
printf.c:564:73: warning: operand of ? changes signedness: 'int' to 'unsigned long' [-Wsign-conversion]
    idx = _ntoa_long(out, buffer, idx, maxlen, (expval < 0) ? -expval : expval, expval < 0, 10, 0, minwidth-1, FLAGS_ZEROPAD | FLAGS_PLUS);
          ~~~~~~~~~~                                                    ^~~~~~
5 warnings generated.
```

After this patch:

```bash
❯ clang-11 -Wall -Wextra -Weverything -c printf.c -o /dev/null
In file included from printf.c:36:
./printf.h:33:9: warning: macro name is a reserved identifier [-Wreserved-id-macro]
 #define _PRINTF_H_
        ^
1 warning generated.
```